### PR TITLE
Options dialog get methods has been removed

### DIFF
--- a/GeoContextQGISPlugin_options_dialog.py
+++ b/GeoContextQGISPlugin_options_dialog.py
@@ -41,28 +41,6 @@ class OptionsDialog(QDialog, FORM_CLASS):
         self.lineSchema.setValue(settings.value('geocontext-qgis-plugin/schema', '', type=str))
         self.checkAutoClear.setChecked(settings.value('geocontext-qgis-plugin/auto_clear_table', False, type=bool))
 
-    def get_schema(self):
-        """Gets the already-set schema URL. This is set using this
-        dialog
-
-        :returns: A URL for the docs used to retrieve the schema
-        :rtype: String
-        """
-
-        url = self.lineUrl.value()
-        return url
-
-    def get_url(self):
-        """Gets the base URL on which requests will be performed. This is set
-        by this dialog
-
-        :returns: A vector point layer that contains nodes as attributes.
-        :rtype: QgsVectorLayer
-        """
-
-        schema = self.lineSchema.value()
-        return schema
-
     def set_url(self):
         """Sets the base URL which will be used to request data/values.
         This can be set using this dialog.


### PR DESCRIPTION
Get methods has been removed from the options dialog class. These methods is no longer required because the URL, schema and auto table clear options is stored using QgsSettings